### PR TITLE
Warn when patch isn't specified

### DIFF
--- a/crates/uv-resolver/src/requires_python.rs
+++ b/crates/uv-resolver/src/requires_python.rs
@@ -248,9 +248,9 @@ impl RequiresPython {
         self.range.lower().as_ref() == Bound::Unbounded
     }
 
-    /// Returns `true` if the `Requires-Python` specifier is set to a specific version
-    /// without a patch version. (e.g. `==3.10`)
-    pub fn is_matching_without_patch(&self) -> bool {
+    /// Returns `true` if the `Requires-Python` specifier is set to an exact version
+    /// without specifying a patch version. (e.g. `==3.10`)
+    pub fn is_exact_without_patch(&self) -> bool {
         match self.range.lower().as_ref() {
             Bound::Included(version) => {
                 version.release().len() == 2

--- a/crates/uv-resolver/src/requires_python.rs
+++ b/crates/uv-resolver/src/requires_python.rs
@@ -248,6 +248,18 @@ impl RequiresPython {
         self.range.lower().as_ref() == Bound::Unbounded
     }
 
+    /// Returns `true` if the `Requires-Python` specifier is set to a specific version
+    /// without a patch version. (e.g. `==3.10`)
+    pub fn is_matching_without_patch(&self) -> bool {
+        match self.range.lower().as_ref() {
+            Bound::Included(version) => {
+                version.release().len() == 2
+                    && self.range.upper().as_ref() == Bound::Included(version)
+            }
+            _ => false,
+        }
+    }
+
     /// Returns the [`RequiresPythonBound`] truncated to the major and minor version.
     pub fn bound_major_minor(&self) -> LowerBound {
         match self.range.lower().as_ref() {

--- a/crates/uv-resolver/src/requires_python/tests.rs
+++ b/crates/uv-resolver/src/requires_python/tests.rs
@@ -134,3 +134,26 @@ fn upper_bound_ordering() {
         }
     }
 }
+
+#[test]
+fn is_matching_without_patch() {
+    let test_cases = [
+        ("==3.12", true),
+        ("==2.7", true),
+        ("==3.10, <3.11", true),
+        ("==3.10, <=3.11", true),
+        ("==3.12.1", false),
+        ("==3.12.*", false),
+        ("==3.*", false),
+        (">=3.10", false),
+        (">3.9", false),
+        ("<4.0", false),
+        (">=3.10, <3.11", false),
+        ("", false),
+    ];
+    for (version, expected) in test_cases {
+        let version_specifiers = VersionSpecifiers::from_str(version).unwrap();
+        let requires_python = RequiresPython::from_specifiers(&version_specifiers).unwrap();
+        assert_eq!(requires_python.is_matching_without_patch(), expected);
+    }
+}

--- a/crates/uv-resolver/src/requires_python/tests.rs
+++ b/crates/uv-resolver/src/requires_python/tests.rs
@@ -139,7 +139,6 @@ fn upper_bound_ordering() {
 fn is_matching_without_patch() {
     let test_cases = [
         ("==3.12", true),
-        ("==2.7", true),
         ("==3.10, <3.11", true),
         ("==3.10, <=3.11", true),
         ("==3.12.1", false),

--- a/crates/uv-resolver/src/requires_python/tests.rs
+++ b/crates/uv-resolver/src/requires_python/tests.rs
@@ -136,7 +136,7 @@ fn upper_bound_ordering() {
 }
 
 #[test]
-fn is_matching_without_patch() {
+fn is_exact_without_patch() {
     let test_cases = [
         ("==3.12", true),
         ("==3.10, <3.11", true),
@@ -153,6 +153,6 @@ fn is_matching_without_patch() {
     for (version, expected) in test_cases {
         let version_specifiers = VersionSpecifiers::from_str(version).unwrap();
         let requires_python = RequiresPython::from_specifiers(&version_specifiers).unwrap();
-        assert_eq!(requires_python.is_matching_without_patch(), expected);
+        assert_eq!(requires_python.is_exact_without_patch(), expected);
     }
 }

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -335,6 +335,8 @@ async fn do_lock(
             let default =
                 RequiresPython::greater_than_equal_version(&interpreter.python_minor_version());
             warn_user_once!("The workspace `requires-python` value does not contain a lower bound: `{requires_python}`. Set a lower bound to indicate the minimum compatible Python version (e.g., `{default}`).");
+        } else if requires_python.is_matching_without_patch() {
+            warn_user_once!("The workspace `requires-python` value does not have a patch version: `{requires_python}`. It will be interpreted as `{requires_python}.0`. Did you mean `{requires_python}.*`?");
         }
         requires_python
     } else {

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -335,8 +335,8 @@ async fn do_lock(
             let default =
                 RequiresPython::greater_than_equal_version(&interpreter.python_minor_version());
             warn_user_once!("The workspace `requires-python` value does not contain a lower bound: `{requires_python}`. Set a lower bound to indicate the minimum compatible Python version (e.g., `{default}`).");
-        } else if requires_python.is_matching_without_patch() {
-            warn_user_once!("The workspace `requires-python` value does not have a patch version: `{requires_python}`. It will be interpreted as `{requires_python}.0`. Did you mean `{requires_python}.*`?");
+        } else if requires_python.is_exact_without_patch() {
+            warn_user_once!("The workspace `requires-python` value contains an exact match without a patch version: `{requires_python}`. When omitted, the patch version is implicitly `0`, e.g., `{requires_python}.0`. Did you mean `{requires_python}.*`?");
         }
         requires_python
     } else {

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -3530,6 +3530,7 @@ fn lock_requires_python_exact() -> Result<()> {
 
     ----- stderr -----
     Using CPython 3.12.[X]
+    warning: The workspace `requires-python` value does not have a patch version: `==3.12`. It will be interpreted as `==3.12.[X]`. Did you mean `==3.12.*`?
     Resolved 2 packages in [TIME]
     "###);
 
@@ -3586,6 +3587,7 @@ fn lock_requires_python_exact() -> Result<()> {
 
     ----- stderr -----
     Using CPython 3.12.[X]
+    warning: The workspace `requires-python` value does not have a patch version: `==3.12`. It will be interpreted as `==3.12.[X]`. Did you mean `==3.12.*`?
     Resolved 2 packages in [TIME]
     "###);
 

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -3530,7 +3530,7 @@ fn lock_requires_python_exact() -> Result<()> {
 
     ----- stderr -----
     Using CPython 3.12.[X]
-    warning: The workspace `requires-python` value does not have a patch version: `==3.12`. It will be interpreted as `==3.12.[X]`. Did you mean `==3.12.*`?
+    warning: The workspace `requires-python` value contains an exact match without a patch version: `==3.12`. When omitted, the patch version is implicitly `0`, e.g., `==3.12.[X]`. Did you mean `==3.12.*`?
     Resolved 2 packages in [TIME]
     "###);
 
@@ -3587,7 +3587,7 @@ fn lock_requires_python_exact() -> Result<()> {
 
     ----- stderr -----
     Using CPython 3.12.[X]
-    warning: The workspace `requires-python` value does not have a patch version: `==3.12`. It will be interpreted as `==3.12.[X]`. Did you mean `==3.12.*`?
+    warning: The workspace `requires-python` value contains an exact match without a patch version: `==3.12`. When omitted, the patch version is implicitly `0`, e.g., `==3.12.[X]`. Did you mean `==3.12.*`?
     Resolved 2 packages in [TIME]
     "###);
 


### PR DESCRIPTION
When patch version isn't specified and a matching version is referenced, it will default patch to 0 which could be unclear/confusing. This PR warns the user of that default.

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

The first part of this issue https://github.com/astral-sh/uv/issues/7426. Will tackle the second part mentioned (`~=`) in a separate PR once I know this is the correct way to warn users.

## Test Plan

<!-- How was it tested? -->

`cargo run --features tracing -- pip install black==24.8 --verbose` should result in a warning message: 

```
WARN Specified version `24.8` will be interpreted as `24.8.0`. Did you mean `24.8.*`?
```

I couldn't find a good example of test cases for `warn` function calls and didn't know the best way to add it, but more than happy to do so. If someone could point me in the right direction that would be much appreciated :) 